### PR TITLE
[CHORE] Setup foundation classes for supporting localization

### DIFF
--- a/Reportedly.xcodeproj/project.pbxproj
+++ b/Reportedly.xcodeproj/project.pbxproj
@@ -8,12 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		241F08FE256E6ACC00EC3120 /* CGFloat+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241F08FD256E6ACC00EC3120 /* CGFloat+Extensions.swift */; };
+		24161AAA25665A6F00149CBE /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 24161AA825665A6F00149CBE /* Localizable.strings */; };
+		24161AB525665FE600149CBE /* StringResource+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24161AB425665FE600149CBE /* StringResource+Extensions.swift */; };
+		24161ABA2566607600149CBE /* LanguageSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24161AB92566607600149CBE /* LanguageSystem.swift */; };
 		243A35CC25679DEF00390E9E /* Thread+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243A35CB25679DEF00390E9E /* Thread+Extensions.swift */; };
 		244085A825594159007C6C06 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085A725594159007C6C06 /* AppDelegate.swift */; };
 		244085B025594159007C6C06 /* Application.AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085AF25594159007C6C06 /* Application.AppDelegate.swift */; };
 		244085B325594159007C6C06 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085B225594159007C6C06 /* Constants.swift */; };
 		244085B625594159007C6C06 /* Entitlements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085B525594159007C6C06 /* Entitlements.swift */; };
-		244085B925594159007C6C06 /* Localizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085B825594159007C6C06 /* Localizations.swift */; };
 		244085BC25594159007C6C06 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085BB25594159007C6C06 /* Resource.swift */; };
 		244085C225594159007C6C06 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085C125594159007C6C06 /* Models.swift */; };
 		244085C825594159007C6C06 /* URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085C725594159007C6C06 /* URLOpener.swift */; };
@@ -67,6 +69,10 @@
 		1588AB8A229769879A8BDAE9 /* Pods-Reportedly.uat.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Reportedly.uat.xcconfig"; path = "Target Support Files/Pods-Reportedly/Pods-Reportedly.uat.xcconfig"; sourceTree = "<group>"; };
 		20CEDDFBC3FE9DB9AFA39FC1 /* Pods-Reportedly.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Reportedly.debug.xcconfig"; path = "Target Support Files/Pods-Reportedly/Pods-Reportedly.debug.xcconfig"; sourceTree = "<group>"; };
 		241F08FD256E6ACC00EC3120 /* CGFloat+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGFloat+Extensions.swift"; sourceTree = "<group>"; };
+		24161AA925665A6F00149CBE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		24161AB025665B3000149CBE /* th-TH */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "th-TH"; path = "th-TH.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		24161AB425665FE600149CBE /* StringResource+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringResource+Extensions.swift"; sourceTree = "<group>"; };
+		24161AB92566607600149CBE /* LanguageSystem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageSystem.swift; sourceTree = "<group>"; };
 		243A35CB25679DEF00390E9E /* Thread+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Thread+Extensions.swift"; sourceTree = "<group>"; };
 		244085A425594159007C6C06 /* Reportedly.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reportedly.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		244085A725594159007C6C06 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -76,7 +82,6 @@
 		244085AF25594159007C6C06 /* Application.AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.AppDelegate.swift; sourceTree = "<group>"; };
 		244085B225594159007C6C06 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		244085B525594159007C6C06 /* Entitlements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entitlements.swift; sourceTree = "<group>"; };
-		244085B825594159007C6C06 /* Localizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localizations.swift; sourceTree = "<group>"; };
 		244085BB25594159007C6C06 /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		244085C125594159007C6C06 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		244085C725594159007C6C06 /* URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLOpener.swift; sourceTree = "<group>"; };
@@ -239,7 +244,7 @@
 		244085B725594159007C6C06 /* Localizations */ = {
 			isa = PBXGroup;
 			children = (
-				244085B825594159007C6C06 /* Localizations.swift */,
+				24161AA825665A6F00149CBE /* Localizable.strings */,
 			);
 			path = Localizations;
 			sourceTree = "<group>";
@@ -259,10 +264,11 @@
 				24820DCD2563873F0072D245 /* CGAffineTransform+Extensions.swift */,
 				241F08FD256E6ACC00EC3120 /* CGFloat+Extensions.swift */,
 				24CB9668255E846B00AAC566 /* String+Extensions.swift */,
+				24161AB425665FE600149CBE /* StringResource+Extensions.swift */,
+				243A35CB25679DEF00390E9E /* Thread+Extensions.swift */,
 				24EE32E325628F2900A9C0DC /* UIButton+Extensions.swift */,
 				24CB968D255E8D3500AAC566 /* UIColor+Extensions.swift */,
 				24EE32D825628C7100A9C0DC /* UITextField+Extensions.swift */,
-				243A35CB25679DEF00390E9E /* Thread+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -303,6 +309,7 @@
 		244085CC25594159007C6C06 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				24161AB92566607600149CBE /* LanguageSystem.swift */,
 				24CB9688255E8B5400AAC566 /* ColorSystem.swift */,
 				24CB967E255E88FF00AAC566 /* BuildConfiguration.swift */,
 				244085CD25594159007C6C06 /* Logger.swift */,
@@ -478,6 +485,7 @@
 			knownRegions = (
 				en,
 				Base,
+				"th-TH",
 			);
 			mainGroup = 2440859B25594159007C6C06;
 			productRefGroup = 244085A525594159007C6C06 /* Products */;
@@ -497,6 +505,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				244085D32559415A007C6C06 /* Assets.xcassets in Resources */,
+				24161AAA25665A6F00149CBE /* Localizable.strings in Resources */,
 				244085D62559415A007C6C06 /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -586,7 +595,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				244085D125594159007C6C06 /* LabelWithLinkView.swift in Sources */,
-				244085B925594159007C6C06 /* Localizations.swift in Sources */,
 				244085B025594159007C6C06 /* Application.AppDelegate.swift in Sources */,
 				24CB9661255E836C00AAC566 /* LoginEmailRouter.swift in Sources */,
 				244085CB25594159007C6C06 /* Services.swift in Sources */,
@@ -611,11 +619,13 @@
 				24CB968E255E8D3500AAC566 /* UIColor+Extensions.swift in Sources */,
 				24820DD6256389200072D245 /* CommonViewInput.swift in Sources */,
 				24820DC9256386990072D245 /* ToastPresenter.swift in Sources */,
+				24161ABA2566607600149CBE /* LanguageSystem.swift in Sources */,
 				24CB965E255E836C00AAC566 /* LoginEmailPresenter.swift in Sources */,
 				244085BC25594159007C6C06 /* Resource.swift in Sources */,
 				24CB9684255E896300AAC566 /* ViewController.swift in Sources */,
 				244085A825594159007C6C06 /* AppDelegate.swift in Sources */,
 				244085B325594159007C6C06 /* Constants.swift in Sources */,
+				24161AB525665FE600149CBE /* StringResource+Extensions.swift in Sources */,
 				24820DCE2563873F0072D245 /* CGAffineTransform+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -652,6 +662,15 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		24161AA825665A6F00149CBE /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				24161AA925665A6F00149CBE /* en */,
+				24161AB025665B3000149CBE /* th-TH */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 		244085D42559415A007C6C06 /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -667,6 +686,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -729,6 +749,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -790,6 +811,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -852,6 +874,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -915,6 +938,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -977,6 +1001,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1039,6 +1064,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1099,6 +1125,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/Reportedly/AppDelegate.swift
+++ b/Reportedly/AppDelegate.swift
@@ -10,11 +10,11 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     var window: UIWindow?
     
     // MARK: - Application life cycle
-
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         // Showing the launch screen 0.5s more, right now it is dismissing to fast
@@ -29,24 +29,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
-
+    
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
     }
-
+    
     func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     }
-
+    
     func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
     }
-
+    
     func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
-
-
 }
 

--- a/Reportedly/Application/Constants/Constants.swift
+++ b/Reportedly/Application/Constants/Constants.swift
@@ -1,0 +1,30 @@
+//
+//  Constants.swift
+//  Reportedly
+//
+//  Created by Mikey Pham on 11/13/20.
+//  Copyright © 2020 NimbleHQ. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - General Enums Constants
+
+enum FileType {
+    static let lproj = "lproj"
+}
+
+enum LanguageCode {
+    static let th = "th"
+    static let thTH = "th-TH"
+    static let en = "en"
+}
+
+enum PushNotification {
+    static let languageDidChange = Notification.Name("LanguageSystem.languagedidChangeNotification")
+}
+
+enum UserDefaultsKey {
+    static let appleLanguage = "AppleLanguage"
+}
+

--- a/Reportedly/Application/Constants/TypeAliases.swift
+++ b/Reportedly/Application/Constants/TypeAliases.swift
@@ -8,9 +8,12 @@
 
 import Foundation
 
+// MARK: - General Typealiases
+
 typealias Callback<T> = (T) -> Void
 typealias EmptyCallback = () -> Void
 
 // MARK: - R.Swift related
 
 typealias Asset = R.image
+typealias Localize = R.string.localizable

--- a/Reportedly/Application/Localizations/en.lproj/Localizable.strings
+++ b/Reportedly/Application/Localizations/en.lproj/Localizable.strings
@@ -1,0 +1,19 @@
+//
+//  Localizable.strings (English)
+//  Reportedly
+//
+//  Created by Mikey Pham on 11/19/20.
+//  Copyright © 2020 NimbleHQ. All rights reserved.
+//
+
+"module.LoginEmail.HeaderTitle" = "Reportedly";
+
+"module.LoginEmail.EmailPlaceholder" = "Email";
+
+"module.LoginEmail.PasswordPlaceholder" = "Password";
+
+"module.LoginEmail.LoginButton" = "Login";
+
+"module.LoginEmail.SignupDescription" = "Don't have an account yet?";
+
+"module.LoginEmail.SignupLink" = "Sign up now";

--- a/Reportedly/Application/Localizations/th-TH.lproj/Localizable.strings
+++ b/Reportedly/Application/Localizations/th-TH.lproj/Localizable.strings
@@ -1,0 +1,21 @@
+//
+//  Localizable.strings (Thai)
+//  Reportedly
+//
+//  Created by Mikey Pham on 11/19/20.
+//  Copyright © 2020 NimbleHQ. All rights reserved.
+//
+
+// TODO: To be translated to Thai later
+
+"module.LoginEmail.HeaderTitle" = "Reportedly";
+
+"module.LoginEmail.EmailPlaceholder" = "Email";
+
+"module.LoginEmail.PasswordPlaceholder" = "Password";
+
+"module.LoginEmail.LoginButton" = "Login";
+
+"module.LoginEmail.SignupDescription" = "Don't have an account yet?";
+
+"module.LoginEmail.SignupLink" = "Sign up now";

--- a/Reportedly/Extensions/StringResource+Extensions.swift
+++ b/Reportedly/Extensions/StringResource+Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  StringResource+Extensions.swift
+//  Reportedly
+//
+//  Created by Mikey Pham on 11/19/20.
+//  Copyright © 2020 NimbleHQ. All rights reserved.
+//
+
+import Rswift
+
+extension StringResource {
+    
+    func localized() -> String {
+        let currentLanguage = LanguageSystem.shared.currentLanguage
+        guard let path = currentLanguage.path, let bundle = Bundle(path: path) else {
+            return NSLocalizedString(key, comment: "")
+        }
+        return bundle.localizedString(forKey: key, value: key, table: tableName)
+    }
+    
+    func localized(with arguments: CVarArg...) -> String {
+        return String(format: localized(), locale: .current, arguments: arguments)
+    }
+}

--- a/Reportedly/Extensions/UIButton+Extensions.swift
+++ b/Reportedly/Extensions/UIButton+Extensions.swift
@@ -10,6 +10,10 @@ import UIKit
 
 extension UIButton {
     
+    func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
+        setBackgroundImage(imageWithColor(color: color), for: state)
+    }
+    
     private func imageWithColor(color: UIColor) -> UIImage? {
         let rect = CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
         UIGraphicsBeginImageContext(rect.size)
@@ -22,9 +26,5 @@ extension UIButton {
         UIGraphicsEndImageContext()
         
         return image
-    }
-
-    func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
-        setBackgroundImage(imageWithColor(color: color), for: state)
     }
 }

--- a/Reportedly/Modules/LoginEmail/LoginEmailInteractor.swift
+++ b/Reportedly/Modules/LoginEmail/LoginEmailInteractor.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol LoginEmailInteractorInput: AnyObject {
-
+    
     // TODO: Add login logic functions
 }
 
@@ -19,7 +19,7 @@ protocol LoginEmailInteractorOutput: AnyObject {
 }
 
 final class LoginEmailInteractor: LoginEmailInteractorInput {
-
+    
     weak var output: LoginEmailInteractorOutput?
     
     init(
@@ -32,5 +32,5 @@ final class LoginEmailInteractor: LoginEmailInteractorInput {
 // MARK: - Private Helper
 
 extension LoginEmailInteractor {
-
+    
 }

--- a/Reportedly/Modules/LoginEmail/LoginEmailRouter.swift
+++ b/Reportedly/Modules/LoginEmail/LoginEmailRouter.swift
@@ -26,10 +26,10 @@ final class LoginEmailRouter: LoginEmailRouterInput {
     }
     
     func show(on window: UIWindow) {
-         if let viewController = viewController {
-             let navigationController = NavigationController(rootViewController: viewController)
-             window.rootViewController = navigationController
-             self.window = window
-         }
-     }
+        if let viewController = viewController {
+            let navigationController = NavigationController(rootViewController: viewController)
+            window.rootViewController = navigationController
+            self.window = window
+        }
+    }
 }

--- a/Reportedly/Modules/LoginEmail/LoginEmailViewController.swift
+++ b/Reportedly/Modules/LoginEmail/LoginEmailViewController.swift
@@ -54,11 +54,14 @@ final class LoginEmailViewController: ViewController {
     
     override func setUpTexts() {
         super.setUpTexts()
-        titleLabel.text = "Reportedly"
-        emailField.placeholder = "Email"
-        passwordField.placeholder = "Password"
-        loginButton.setTitle("Login", for: .normal)
-        signupLabelWithLinkView.setText(labelText: "Don't have an account yet?", linkText: "Sign up now")
+        titleLabel.text = Localize.moduleLoginEmailHeaderTitle.localized()
+        emailField.placeholder = Localize.moduleLoginEmailEmailPlaceholder.localized()
+        passwordField.placeholder = Localize.moduleLoginEmailPasswordPlaceholder.localized()
+        loginButton.setTitle(Localize.moduleLoginEmailLoginButton.localized(), for: .normal)
+        signupLabelWithLinkView.setText(
+            labelText: Localize.moduleLoginEmailSignupDescription.localized(),
+            linkText: Localize.moduleLoginEmailSignupLink.localized()
+        )
     }
     
     override func setUpColors() {

--- a/Reportedly/Protocols/CommonViewInput.swift
+++ b/Reportedly/Protocols/CommonViewInput.swift
@@ -9,12 +9,12 @@
 import UIKit
 
 protocol CommonViewInput {
-
+    
     func showToastNotification(message: String)
 }
 
 extension CommonViewInput where Self: UIViewController {
-
+    
     func showToastNotification(message: String) {
         ToastPresenter.shared.showNotification(message)
     }

--- a/Reportedly/Protocols/URLOpener.swift
+++ b/Reportedly/Protocols/URLOpener.swift
@@ -9,22 +9,22 @@
 import UIKit
 
 protocol URLOpener: AnyObject {
-
+    
     func open(
         _ url: URL,
         options: [UIApplication.OpenExternalURLOptionsKey: Any],
         completionHandler completion: Callback<Bool>?
     )
-
+    
     func canOpenURL(_ url: URL) -> Bool
 }
 
 extension URLOpener {
-
+    
     func open(_ url: URL) {
         open(url, options: [:], completionHandler: nil)
     }
-
+    
     func safelyOpen(_ url: URL) {
         if canOpenURL(url) {
             open(url)

--- a/Reportedly/Utilities/ColorSystem.swift
+++ b/Reportedly/Utilities/ColorSystem.swift
@@ -38,7 +38,7 @@ public class ColorSystem {
     private(set) var textHighlightedColor: UIColor!
     private(set) var formsColor: UIColor!
     private(set) var backgroundColor: UIColor!
-
+    
     init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
         // Find last set ColorTheme in userDefault or set it for the first time

--- a/Reportedly/Utilities/LanguageSystem.swift
+++ b/Reportedly/Utilities/LanguageSystem.swift
@@ -1,0 +1,104 @@
+//
+//  LanguageSystem.swift
+//  Reportedly
+//
+//  Created by Mikey Pham on 11/19/20.
+//  Copyright © 2020 NimbleHQ. All rights reserved.
+//
+
+import Foundation
+
+protocol LanguageSystemDelegate {
+    
+    var currentLanguage: LanguageSystem.Language { get }
+    
+    func switchLanguage()
+}
+
+final class LanguageSystem {
+    
+    static let shared = LanguageSystem()
+    
+    private let userDefault = UserDefaults.standard
+    
+    private(set) var currentLanguage: Language {
+        didSet {
+            userDefault.setValue([currentLanguage.locale.identifier], forKey: UserDefaultsKey.appleLanguage)
+            NotificationCenter.default.post(name: PushNotification.languageDidChange, object: nil)
+        }
+    }
+    
+    init() {
+        if let firstIdentifier = userDefault.stringArray(forKey: UserDefaultsKey.appleLanguage)?.first {
+            currentLanguage = Language(identifier: firstIdentifier) ?? .english
+        } else {
+            if let deviceLanguage = Locale.preferredLanguages.first,
+               deviceLanguage.contains(LanguageCode.th) {
+                currentLanguage = .thai
+            } else {
+                currentLanguage = .english
+            }
+        }
+    }
+}
+
+// MARK: - LanguageSystemProtocol
+
+extension LanguageSystem: LanguageSystemDelegate {
+    
+    func switchLanguage() {
+        switch currentLanguage {
+        case .english:
+            currentLanguage = .thai
+        case .thai:
+            currentLanguage = .english
+        }
+    }
+}
+
+// MARK: - LanguageSystem.Language
+extension LanguageSystem {
+    
+    enum Language: CaseIterable {
+        
+        case thai
+        case english
+        
+        init?(identifier: String) {
+            guard let languageCode = Locale(identifier: identifier).languageCode,
+                  let matchedLocale = Language.allCases.first(where: { $0.locale.languageCode == languageCode })
+            else { return nil }
+            self = matchedLocale
+        }
+        
+        var locale: Locale {
+            switch self {
+            case .thai:
+                return Locale(identifier: LanguageCode.th)
+            case .english:
+                return Locale(identifier: LanguageCode.en)
+            }
+        }
+        
+        var calendar: Calendar {
+            switch self {
+            case .thai:
+                return Calendar(identifier: .buddhist)
+            case .english:
+                return Calendar(identifier: .gregorian)
+            }
+        }
+        
+        var path: String? { Bundle.main.path(forResource: resource, ofType: FileType.lproj) }
+        
+        /// This is the name of localization file.
+        private var resource: String {
+            switch self {
+            case .thai:
+                return LanguageCode.thTH
+            case .english:
+                return LanguageCode.en
+            }
+        }
+    }
+}

--- a/Reportedly/Utilities/Logger.swift
+++ b/Reportedly/Utilities/Logger.swift
@@ -55,7 +55,7 @@ final class Logger {
 }
 
 // MARK: - Private
-    
+
 extension Logger {
     
     private func filename(from file: StaticString) -> String {

--- a/UITests/UITests.swift
+++ b/UITests/UITests.swift
@@ -8,29 +8,29 @@
 import XCTest
 
 class UITests: XCTestCase {
-
+    
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
-
+        
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
+        
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
-
+    
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
+    
     func testExample() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
-
+        
         // Use recording to get started writing UI tests.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
-
+    
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
             // This measures how long it takes to launch your application.

--- a/UnitTests/UnitTests.swift
+++ b/UnitTests/UnitTests.swift
@@ -15,25 +15,24 @@ import XCTest
 #endif
 
 class UnitTests: XCTestCase {
-
+    
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-
+    
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
+    
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
-
+    
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {
             // Put the code you want to measure the time of here.
         }
     }
-
 }


### PR DESCRIPTION
## What happened

Creating foundation classes for for supporting translation and localization instead of using hard-coded texts everywhere in the application.
 
## Insight

- Refactor code indentation for the whole project.

- Add `Localizable.strings` files for Thai and English that provides every translatable text used in the app with a key instead of using raw hard-coded text. As a result, whenever we want to use a string for displaying, just need to provide the key instead.
 
## Proof Of Work

New `Localizable.strings` file:
![Screen Shot 2020-11-19 at 16 25 36](https://user-images.githubusercontent.com/70877098/99647100-e1a98e00-2a83-11eb-9a76-bf6a327f2fa8.png)

Usage in code:
![Screen Shot 2020-11-19 at 16 30 18](https://user-images.githubusercontent.com/70877098/99647558-875cfd00-2a84-11eb-8636-394a8bf30f3a.png)


