### PR TITLE
[TASK-3] [Backend] As a user, I can see sign-in screen and use my email and pasword to sign in

### DIFF
--- a/Reportedly.xcodeproj/project.pbxproj
+++ b/Reportedly.xcodeproj/project.pbxproj
@@ -420,8 +420,8 @@
 		244085CF25594159007C6C06 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				241AE5DD257F218400DC3E0E /* LottieView */,
 				24820DC5256386990072D245 /* CommonView */,
+				241AE5DD257F218400DC3E0E /* LottieView */,
 				244085D025594159007C6C06 /* LabelWithLinkView.swift */,
 			);
 			path = Views;

--- a/Reportedly.xcodeproj/project.pbxproj
+++ b/Reportedly.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		248C27CE257F6DE300B75CA1 /* ReachabilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248C27CD257F6DE300B75CA1 /* ReachabilityManager.swift */; };
 		248C27F8257F838C00B75CA1 /* Notification+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248C27F7257F838C00B75CA1 /* Notification+Extensions.swift */; };
 		248E93662580A43300839C68 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E93652580A43300839C68 /* LoadingView.swift */; };
+		248E936B2580B07600839C68 /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248E936A2580B07600839C68 /* LoginRequest.swift */; };
 		24CB965D255E836C00AAC566 /* LoginEmailModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB9658255E836C00AAC566 /* LoginEmailModule.swift */; };
 		24CB965E255E836C00AAC566 /* LoginEmailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB9659255E836C00AAC566 /* LoginEmailPresenter.swift */; };
 		24CB965F255E836C00AAC566 /* LoginEmailInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB965A255E836C00AAC566 /* LoginEmailInteractor.swift */; };
@@ -163,6 +164,7 @@
 		248C27CD257F6DE300B75CA1 /* ReachabilityManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReachabilityManager.swift; sourceTree = "<group>"; };
 		248C27F7257F838C00B75CA1 /* Notification+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Extensions.swift"; sourceTree = "<group>"; };
 		248E93652580A43300839C68 /* LoadingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		248E936A2580B07600839C68 /* LoginRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
 		24CB9658255E836C00AAC566 /* LoginEmailModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEmailModule.swift; sourceTree = "<group>"; };
 		24CB9659255E836C00AAC566 /* LoginEmailPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEmailPresenter.swift; sourceTree = "<group>"; };
 		24CB965A255E836C00AAC566 /* LoginEmailInteractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEmailInteractor.swift; sourceTree = "<group>"; };
@@ -496,6 +498,7 @@
 		248C2785257F699800B75CA1 /* Requests */ = {
 			isa = PBXGroup;
 			children = (
+				248E936A2580B07600839C68 /* LoginRequest.swift */,
 				2480CAD7257F9ADF00B079DF /* SignupRequest.swift */,
 			);
 			path = Requests;
@@ -525,9 +528,9 @@
 			isa = PBXGroup;
 			children = (
 				24CB9658255E836C00AAC566 /* LoginEmailModule.swift */,
-				24CB9659255E836C00AAC566 /* LoginEmailPresenter.swift */,
-				24CB965A255E836C00AAC566 /* LoginEmailInteractor.swift */,
 				24CB965B255E836C00AAC566 /* LoginEmailViewController.swift */,
+				24CB965A255E836C00AAC566 /* LoginEmailInteractor.swift */,
+				24CB9659255E836C00AAC566 /* LoginEmailPresenter.swift */,
 				24CB965C255E836C00AAC566 /* LoginEmailRouter.swift */,
 			);
 			path = LoginEmail;
@@ -554,11 +557,11 @@
 		24CF122925762E44006D6BA0 /* Signup */ = {
 			isa = PBXGroup;
 			children = (
-				24CF122A25762EB2006D6BA0 /* SignupRouter.swift */,
 				24CF122B25762EB2006D6BA0 /* SignupModule.swift */,
 				24CF122C25762EB2006D6BA0 /* SignupViewController.swift */,
 				24CF122D25762EB2006D6BA0 /* SignupInteractor.swift */,
 				24CF122E25762EB2006D6BA0 /* SignupPresenter.swift */,
+				24CF122A25762EB2006D6BA0 /* SignupRouter.swift */,
 			);
 			path = Signup;
 			sourceTree = "<group>";
@@ -857,6 +860,7 @@
 				244085BC25594159007C6C06 /* Resource.swift in Sources */,
 				24CB9684255E896300AAC566 /* ViewController.swift in Sources */,
 				244085A825594159007C6C06 /* AppDelegate.swift in Sources */,
+				248E936B2580B07600839C68 /* LoginRequest.swift in Sources */,
 				24CF123025762EB2006D6BA0 /* SignupModule.swift in Sources */,
 				24CF122F25762EB2006D6BA0 /* SignupRouter.swift in Sources */,
 				2484C9052578F3E300DAB3BB /* UserManagementInterceptor.swift in Sources */,

--- a/Reportedly/Application/Constants/Enums.swift
+++ b/Reportedly/Application/Constants/Enums.swift
@@ -12,7 +12,7 @@ import Foundation
 
 enum RequestResourceType: String {
     case signup = "signup"
-    case signin = "signin"
+    case login = "login"
 }
 
 enum RequestType {

--- a/Reportedly/Modules/Authentication/LoginEmail/LoginEmailInteractor.swift
+++ b/Reportedly/Modules/Authentication/LoginEmail/LoginEmailInteractor.swift
@@ -10,27 +10,43 @@ import Foundation
 
 protocol LoginEmailInteractorInput: AnyObject {
     
-    // TODO: Add login logic functions
+    func login(email: String, password: String)
 }
 
 protocol LoginEmailInteractorOutput: AnyObject {
     
-    // TODO: Add login completion callbacks functions
+    func didLogin()
+    func didFailToLogin(error: ResponseError)
 }
 
-final class LoginEmailInteractor: LoginEmailInteractorInput {
+final class LoginEmailInteractor {
+    
+    private let authenticationAPIService: AuthenticationAPIServiceProtocol
     
     weak var output: LoginEmailInteractorOutput?
     
     init(
-        // TODO: Add shared managers here
+        authenticationAPIService: AuthenticationAPIServiceProtocol
     ) {
-        
+        self.authenticationAPIService = authenticationAPIService
     }
 }
 
-// MARK: - Private Helper
+// MARK: - LoginEmailInteractorInput
 
-extension LoginEmailInteractor {
+extension LoginEmailInteractor: LoginEmailInteractorInput {
     
+    func login(email: String, password: String) {
+        let request = LoginRequest(
+            email: email,
+            password: password
+        )
+        authenticationAPIService.login(with: request) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success: self.output?.didLogin()
+            case .failure(let error): self.output?.didFailToLogin(error: error)
+            }
+        }
+    }
 }

--- a/Reportedly/Modules/Authentication/LoginEmail/LoginEmailInteractor.swift
+++ b/Reportedly/Modules/Authentication/LoginEmail/LoginEmailInteractor.swift
@@ -16,7 +16,7 @@ protocol LoginEmailInteractorInput: AnyObject {
 protocol LoginEmailInteractorOutput: AnyObject {
     
     func didLogin()
-    func didFailToLogin(error: ResponseError)
+    func didFailToLogin(_ error: ResponseError)
 }
 
 final class LoginEmailInteractor {
@@ -45,7 +45,7 @@ extension LoginEmailInteractor: LoginEmailInteractorInput {
             guard let self = self else { return }
             switch result {
             case .success: self.output?.didLogin()
-            case .failure(let error): self.output?.didFailToLogin(error: error)
+            case .failure(let error): self.output?.didFailToLogin(error)
             }
         }
     }

--- a/Reportedly/Modules/Authentication/LoginEmail/LoginEmailModule.swift
+++ b/Reportedly/Modules/Authentication/LoginEmail/LoginEmailModule.swift
@@ -32,7 +32,9 @@ final class LoginEmailModule {
     
     init() {
         view = LoginEmailViewController()
-        interactor = LoginEmailInteractor()
+        interactor = LoginEmailInteractor(
+            authenticationAPIService: AuthenticationAPIService()
+        )
         router = LoginEmailRouter(urlOpener: UIApplication.shared)
         presenter = LoginEmailPresenter(interactor: interactor, router: router)
         

--- a/Reportedly/Modules/Authentication/LoginEmail/LoginEmailPresenter.swift
+++ b/Reportedly/Modules/Authentication/LoginEmail/LoginEmailPresenter.swift
@@ -35,8 +35,10 @@ extension LoginEmailPresenter: LoginEmailViewOutput {
     
     func didTapLoginButton() {
         guard let email = view?.emailFieldText, let password = view?.passwordFieldText else { return }
-        // TODO: Implement login logic here
-        view?.showToastNotification(message: "Login button pressed with\nemail: \(email)\npassword: \(password)")
+        view?.dismissKeyboard()
+        view?.showLoadingView(message: Localize.genericLoading.localized())
+        interactor.login(email: email, password: password)
+        log.debug("Login button pressed with\nemail: \(email)\npassword: \(password)")
     }
     
     func didTapSignupLinkView() {
@@ -54,4 +56,15 @@ extension LoginEmailPresenter: LoginEmailInput {
 
 extension LoginEmailPresenter: LoginEmailInteractorOutput {
     
+    func didLogin() {
+        view?.hideLoadingView()
+        view?.showSuccessOverlayView {
+            // TODO: Send user to Home Screen
+        }
+    }
+    
+    func didFailToLogin(error: ResponseError) {
+        view?.hideLoadingView()
+        view?.showToastNotification(message: error.message)
+    }
 }

--- a/Reportedly/Modules/Authentication/LoginEmail/LoginEmailPresenter.swift
+++ b/Reportedly/Modules/Authentication/LoginEmail/LoginEmailPresenter.swift
@@ -63,7 +63,7 @@ extension LoginEmailPresenter: LoginEmailInteractorOutput {
         }
     }
     
-    func didFailToLogin(error: ResponseError) {
+    func didFailToLogin(_ error: ResponseError) {
         view?.hideLoadingView()
         view?.showToastNotification(message: error.message)
     }

--- a/Reportedly/Modules/Authentication/LoginEmail/LoginEmailViewController.swift
+++ b/Reportedly/Modules/Authentication/LoginEmail/LoginEmailViewController.swift
@@ -16,6 +16,7 @@ protocol LoginEmailViewInput: AnyObject, CommonViewInput {
     var isValidEmailAndPassword: Bool { get }
     
     func configure()
+    func dismissKeyboard()
     func setLoginButtonEnabled(_ isEnabled: Bool)
     // TODO: Add loading states functions here
 }
@@ -107,6 +108,10 @@ extension LoginEmailViewController: LoginEmailViewInput {
     func configure() {
         setUpLayouts()
         setUpViews()
+    }
+    
+    func dismissKeyboard() {
+        dismissKeyboard(nil)
     }
     
     func setLoginButtonEnabled(_ isEnabled: Bool) {

--- a/Reportedly/Services/Network/RESTful/API/AuthenticationAPIService.swift
+++ b/Reportedly/Services/Network/RESTful/API/AuthenticationAPIService.swift
@@ -25,7 +25,11 @@ final class AuthenticationAPIService: BaseAPIService, AuthenticationAPIServicePr
 
     // MARK: - Private Variables
     
-    private var tokenData: Token?
+    // TODO: - Removed this hard-coded authentication token when server support user's token
+    private var tokenData: Token? = Token(
+        value: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMiIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTYwNzMzMjUyNCwiZXhwIjoxNjA3NDE4OTI0LCJqdGkiOiI0NzVmNzE5ZS02ZTNmLTRmYTUtYjI3Zi02ZDkxMGM5NGRiMzgifQ.l9mFj8r8tfjk0oVyBPKy5HEvBItFzZ-iIlAjcAmKuhA",
+        isExpired: true
+    )
 
     // MARK: - Public Functions
     

--- a/Reportedly/Services/Network/RESTful/API/AuthenticationAPIService.swift
+++ b/Reportedly/Services/Network/RESTful/API/AuthenticationAPIService.swift
@@ -10,6 +10,8 @@ import Alamofire
 
 protocol AuthenticationAPIServiceProtocol {
 
+    func login(with loginRequest: LoginRequest, completion: @escaping ResultRestfulCompletion)
+    
     func signUp(with signupRequest: SignupRequest, completion: @escaping ResultRestfulCompletion)
 }
 
@@ -27,9 +29,26 @@ final class AuthenticationAPIService: BaseAPIService, AuthenticationAPIServicePr
 
     // MARK: - Public Functions
     
-    func signIn(completion: SuccessCompletion? = nil) {
-        // TODO: Add signin API logic here
-        completion?(true)
+    func login(with loginRequest: LoginRequest, completion: @escaping ResultRestfulCompletion) {
+        request(
+            topic: RequestResourceType.login.rawValue,
+            method: .post,
+            bodyParams: loginRequest.toDictionary(),
+            shouldAuthenticate: false
+        ) { data, success, error in
+            Thread.executeOnMainThread {
+                if let error = error {
+                    return completion(.failure(error))
+                }
+                guard let success = success else {
+                    return completion(.failure(ResponseError(.other)))
+                }
+                switch success.type {
+                case .noContent: completion(.success(ResponseSuccess(.noContent)))
+                case .success: completion(.success(ResponseSuccess(.success)))
+                }
+            }
+        }
     }
     
     func signUp(with signupRequest: SignupRequest, completion: @escaping ResultRestfulCompletion) {

--- a/Reportedly/Services/Network/RESTful/API/Base/RequestInterceptor.swift
+++ b/Reportedly/Services/Network/RESTful/API/Base/RequestInterceptor.swift
@@ -137,7 +137,7 @@ class RequestInterceptor {
                 log.info("-------------END-------------")
                 return completion(nil, ResponseSuccess(.noContent), nil)
             }
-            if let error = (dataDict["errors"] as? JSONDictionary)?["message"] as? String {
+            if let error = ((dataDict["errors"] ?? dataDict["error"]) as? JSONDictionary)?["message"] as? String {
                 errorMessage = error
             }
         } else {

--- a/Reportedly/Services/Network/RESTful/Requests/LoginRequest.swift
+++ b/Reportedly/Services/Network/RESTful/Requests/LoginRequest.swift
@@ -1,29 +1,25 @@
 //
-//  SignupRequest.swift
+//  LoginRequest.swift
 //  Reportedly
 //
-//  Created by Mikey Pham on 12/8/20.
+//  Created by Mikey Pham on 12/9/20.
 //  Copyright © 2020 NimbleHQ. All rights reserved.
 //
 
 import Foundation
 
-struct SignupRequest: Encodable {
+struct LoginRequest: Encodable {
     
     // MARK: - Request Variables
     
     let email: String
     let password: String
-    let passwordConfirmation: String
-    let slackId: String
 }
 
-extension SignupRequest {
+extension LoginRequest {
     
     enum CodingKeys: String, CodingKey {
         case email = "user[email]"
         case password = "user[password]"
-        case passwordConfirmation = "user[password_confirmation]"
-        case slackId = "user[slack_id]"
     }
 }


### PR DESCRIPTION
https://github.com/nimblehq/reportedly_ios/projects/1#card-49056834

## What happened

**Descriptions**
When first entering the app, users will see the Login screen. When signing-in, they will be redirected to the home dashboard.

This PR is for connecting to login endpoint and trigger the actual call to backend successfully. Errors will be shown according to backend's message.
 
## Insight

- [x] Connect to login API
 
## Proof Of Work

Successful login API call log:

```
2020-12-09 14:28:02.935254+0700 Reportedly-Staging[19522:306492] [Logger] > 🍆 ---------------Making request---------------
2020-12-09 14:28:02.935435+0700 Reportedly-Staging[19522:306492] [Logger] > 🍆 URL Requesting... https://reportedly-staging.herokuapp.com/api/v1/login
2020-12-09 14:28:02.936168+0700 Reportedly-Staging[19522:306492] [Logger] > 🍆 Method HTTPMethod(rawValue: "POST")
2020-12-09 14:28:02.936343+0700 Reportedly-Staging[19522:306492] [Logger] > 🍆 With queryParams [:]
2020-12-09 14:28:02.936556+0700 Reportedly-Staging[19522:306492] [Logger] > 🍆 With bodyParams ["user[email]": minh@nimblehq.co, "user[password]": 12345678]
2020-12-09 14:28:02.936705+0700 Reportedly-Staging[19522:306492] [Logger] > 🍆 ---------------END---------------
2020-12-09 14:28:02.941717+0700 Reportedly-Staging[19522:306492] [Logger] LoginEmailPresenter.didTapLoginButton():41
> 🍏 Login button pressed with
email: minh@nimblehq.co
password: 12345678
2020-12-09 14:28:03.155174+0700 Reportedly-Staging[19522:307008] [] nw_protocol_get_quic_image_block_invoke dlopen libquic failed
2020-12-09 14:28:04.552873+0700 Reportedly-Staging[19522:306792] [Logger] > 🍆 -------------RESPONSE RESULT-------------
2020-12-09 14:28:04.554054+0700 Reportedly-Staging[19522:306792] [Logger] > 🍆 <NSHTTPURLResponse: 0x600000651a60> { URL: https://reportedly-staging.herokuapp.com/api/v1/login } { Status Code: 200, Headers {
    Authorization =     (
        "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwic2NwIjoidXNlciIsImF1ZCI6bnVsbCwiaWF0IjoxNjA3NDk4ODg0LCJleHAiOjE2MDgxMDM2ODQsImp0aSI6IjdlNTgwYTYwLTg0MmQtNGY3ZC05ZDMwLTc0ZGFkNWY3YWY3NyJ9.3lUZrvWabBtCk_vlTiuHL5EBwXwIN8F6w-8NE4fnd5c"
    );
    "Cache-Control" =     (
        "max-age=0, private, must-revalidate"
    );
    Connection =     (
        "keep-alive"
    );
    "Content-Encoding" =     (
        gzip
    );
    "Content-Type" =     (
        "application/json; charset=utf-8"
    );
    Date =     (
        "Wed, 09 Dec 2020 07:28:03 GMT"
    );
    Etag =     (
        "W/\"b0594ae69e2241f72a9e599e674f888a\""
    );
    "Referrer-Policy" =     (
        "strict-origin-when-cross-origin"
    );
    Server =     (
        Cowboy
    );
    "Transfer-Encoding" =     (
        Identity
    );
    Vary =     (
        "Accept-Encoding, Origin"
    );
    Via =     (
        "1.1 vegur"
    );
    "X-Content-Type-Options" =     (
        nosniff
    );
    "X-Download-Options" =     (
        noopen
    );
    "X-Frame-Options" =     (
        SAMEORIGIN
    );
    "X-Permitted-Cross-Domain-Policies" =     (
        none
    );
    "X-Request-Id" =     (
        "54f28c3e-2eca-4d42-9a04-f10420d0f062"
    );
    "X-Runtime" =     (
        "0.390153"
    );
    "X-Xss-Protection" =     (
        "1; mode=block"
    );
} }
2020-12-09 14:28:04.555498+0700 Reportedly-Staging[19522:306792] [Logger] > 🍆 Data ["data": {
    email = "minh@nimblehq.co";
    id = 2;
    "slack_id" = U019TLN0E7Q;
}, "status": {
    message = "Logged in successfully.";
}]
2020-12-09 14:28:04.555711+0700 Reportedly-Staging[19522:306792] [Logger] > 🍆 -------------END-------------
```