### PR TITLE
[TASK-10] [Integrate] As a user, I can set an alarm within the local standup report time for reminding

### DIFF
--- a/Reportedly.xcodeproj/project.pbxproj
+++ b/Reportedly.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		244085D62559415A007C6C06 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 244085D42559415A007C6C06 /* LaunchScreen.storyboard */; };
 		244085E12559415A007C6C06 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085E02559415A007C6C06 /* UnitTests.swift */; };
 		244085EC2559415A007C6C06 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244085EB2559415A007C6C06 /* UITests.swift */; };
+		247186F6258102D300ABD1C0 /* LocalNotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247186F5258102D300ABD1C0 /* LocalNotificationScheduler.swift */; };
 		2480CAD8257F9ADF00B079DF /* SignupRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2480CAD7257F9ADF00B079DF /* SignupRequest.swift */; };
 		24820DC8256386990072D245 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24820DC6256386990072D245 /* ToastView.swift */; };
 		24820DC9256386990072D245 /* CommonViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24820DC7256386990072D245 /* CommonViewPresenter.swift */; };
@@ -141,6 +142,7 @@
 		244085E72559415A007C6C06 /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		244085EB2559415A007C6C06 /* UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
 		244085ED2559415A007C6C06 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		247186F5258102D300ABD1C0 /* LocalNotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationScheduler.swift; sourceTree = "<group>"; };
 		2480CAD7257F9ADF00B079DF /* SignupRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRequest.swift; sourceTree = "<group>"; };
 		24820DC6256386990072D245 /* ToastView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		24820DC7256386990072D245 /* CommonViewPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommonViewPresenter.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				248C27AA257F6B4A00B75CA1 /* Obfuscator.swift */,
 				248C27CD257F6DE300B75CA1 /* ReachabilityManager.swift */,
 				241AE5C9257F204C00DC3E0E /* LottieAnimationFactory.swift */,
+				247186F5258102D300ABD1C0 /* LocalNotificationScheduler.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -839,6 +842,7 @@
 				248E93662580A43300839C68 /* LoadingView.swift in Sources */,
 				2484C9152578F63300DAB3BB /* UserManager.swift in Sources */,
 				244085CB25594159007C6C06 /* Network.swift in Sources */,
+				247186F6258102D300ABD1C0 /* LocalNotificationScheduler.swift in Sources */,
 				244085B625594159007C6C06 /* Entitlements.swift in Sources */,
 				243A35CC25679DEF00390E9E /* Thread+Extensions.swift in Sources */,
 				24CB965D255E836C00AAC566 /* LoginEmailModule.swift in Sources */,

--- a/Reportedly/AppDelegate.swift
+++ b/Reportedly/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import UserNotifications
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -19,6 +20,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Showing the launch screen 0.5s more, right now it is dismissing to fast
         Thread.sleep(forTimeInterval: 0.5)
+        
+        // Request for notifications permission when first open app
+        let options: UNAuthorizationOptions = [.alert, .sound, .badge]
+        UNUserNotificationCenter.current().requestAuthorization(options: options) {
+            (didAllow, error) in
+            if !didAllow {
+                log.error("User has declined notifications")
+            }
+        }
+        LocalNotificationScheduler.shared.setupDailyStandupLocalNotifications()
         
         // Then, show the login screen
         let window = UIWindow(frame: UIScreen.main.bounds)

--- a/Reportedly/AppDelegate.swift
+++ b/Reportedly/AppDelegate.swift
@@ -24,8 +24,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Request for notifications permission when first open app
         let options: UNAuthorizationOptions = [.alert, .sound, .badge]
         UNUserNotificationCenter.current().requestAuthorization(options: options) {
-            (didAllow, error) in
-            if !didAllow {
+            (isAuthorised, error) in
+            if !isAuthorised {
                 log.error("User has declined notifications")
             }
         }

--- a/Reportedly/Application/Constants/Constants.swift
+++ b/Reportedly/Application/Constants/Constants.swift
@@ -28,6 +28,17 @@ enum DateFormat {
     static let yyyy_MM_dd_T_HH_mm_ss_SSSZ = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 }
 
+// TODO: Create constants for hard-coding DayIndex for now, will remove when implement Notification Scheduler Settings feature
+enum DayIndex {
+    static let monday = 2
+    static let friday = 6
+}
+
+// TODO: Create constants for hard-coding HourValue for now, will remove when implement Notification Scheduler Settings feature
+enum HourValue {
+    static let nine = 9
+}
+
 enum FileType {
     static let lproj = "lproj"
 }

--- a/Reportedly/Application/Localizations/en.lproj/Localizable.strings
+++ b/Reportedly/Application/Localizations/en.lproj/Localizable.strings
@@ -42,4 +42,8 @@
 
 "module.Home.MenuLogoutOption" = "Logout";
 
-"module.Loading.Message" = "Loading...";
+"module.Notifications.DailyReportReminderTitle" = "Daily Standup Report";
+
+"module.Notifications.DailyReportReminderDescription" = "Hi, it's time to start the daily standup. Please, open the app and answer your daily questions";
+
+"module.Loader.Message" = "Loading...";

--- a/Reportedly/Application/Localizations/th-TH.lproj/Localizable.strings
+++ b/Reportedly/Application/Localizations/th-TH.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 //
-//  Localizable.strings (English)
+//  Localizable.strings (Thailand)
 //  Reportedly
 //
 //  Created by Mikey Pham on 11/19/20.
@@ -42,4 +42,8 @@
 
 "module.Home.MenuLogoutOption" = "Logout";
 
-"module.Loading.Message" = "Loading...";
+"module.Notifications.DailyReportReminderTitle" = "Daily Standup Report";
+
+"module.Notifications.DailyReportReminderDescription" = "Hi, it's time to start the daily standup. Please, open the app and answer your daily questions";
+
+"module.Loader.Message" = "Loading...";

--- a/Reportedly/Modules/Authentication/LoginEmail/LoginEmailPresenter.swift
+++ b/Reportedly/Modules/Authentication/LoginEmail/LoginEmailPresenter.swift
@@ -36,7 +36,7 @@ extension LoginEmailPresenter: LoginEmailViewOutput {
     func didTapLoginButton() {
         guard let email = view?.emailFieldText, let password = view?.passwordFieldText else { return }
         view?.dismissKeyboard()
-        view?.showLoadingView(message: Localize.moduleLoadingMessage.localized())
+        view?.showLoadingView(message: Localize.moduleLoaderMessage.localized())
         interactor.login(email: email, password: password)
         log.debug("Login button pressed with\nemail: \(email)\npassword: \(password)")
     }

--- a/Reportedly/Modules/Authentication/Signup/SignupPresenter.swift
+++ b/Reportedly/Modules/Authentication/Signup/SignupPresenter.swift
@@ -38,7 +38,7 @@ extension SignupPresenter: SignupViewOutput {
               let slackId = view?.slackIdFieldText
         else { return }
         view?.dismissKeyboard()
-        view?.showLoadingView(message: Localize.moduleLoadingMessage.localized())
+        view?.showLoadingView(message: Localize.moduleLoaderMessage.localized())
         interactor.signup(email: email, password: password, confirmedPassword: confirmedPassword, slackId: slackId)
         log.debug("Signup button pressed with\nemail: \(email)\npassword: \(password)\nconfirmPassword: \(confirmedPassword)\nslackId: \(slackId)")
     }

--- a/Reportedly/Utilities/LocalNotificationScheduler.swift
+++ b/Reportedly/Utilities/LocalNotificationScheduler.swift
@@ -1,0 +1,51 @@
+//
+//  LocalNotificationScheduler.swift
+//  Reportedly
+//
+//  Created by Minh Pham on 09/12/2020.
+//
+
+import Foundation
+import UIKit
+import UserNotifications
+
+final class LocalNotificationScheduler {
+    
+    static let shared = LocalNotificationScheduler()
+    
+    func setupDailyStandupLocalNotifications() {
+        // Create the notification content
+        let content = UNMutableNotificationContent()
+        content.title = "Daily Standup Report"
+        content.body = "Hi, it's time to start the daily standup. Please, open the app and answer your daily questions"
+        content.sound = UNNotificationSound.default
+                        
+        for i in 2...6 {
+            // Configure the recurring date.
+            var dateComponents = DateComponents()
+            dateComponents.calendar = Calendar.current
+
+            dateComponents.weekday = i  // Monday to Friday
+            dateComponents.hour = 9    // 9:00 hours
+               
+            // Create the trigger as a repeating event.
+            let trigger = UNCalendarNotificationTrigger(
+                     dateMatching: dateComponents, repeats: true)
+               
+            // Create the request
+            let uuidString = UUID().uuidString
+            let request = UNNotificationRequest(identifier: uuidString,
+                        content: content, trigger: trigger)
+
+            // Schedule the request with the system.
+            let notificationCenter = UNUserNotificationCenter.current()
+            notificationCenter.add(request) { error in
+                if let error = error {
+                    log.error("Can't add local notification due to: \(error.localizedDescription)")
+                } else {
+                    log.info("Add local notification successfully!")
+                }
+            }
+        }
+    }
+}

--- a/Reportedly/Utilities/LocalNotificationScheduler.swift
+++ b/Reportedly/Utilities/LocalNotificationScheduler.swift
@@ -16,17 +16,17 @@ final class LocalNotificationScheduler {
     func setupDailyStandupLocalNotifications() {
         // Create the notification content
         let content = UNMutableNotificationContent()
-        content.title = "Daily Standup Report"
-        content.body = "Hi, it's time to start the daily standup. Please, open the app and answer your daily questions"
+        content.title = Localize.moduleNotificationsDailyReportReminderTitle.localized()
+        content.body = Localize.moduleNotificationsDailyReportReminderDescription.localized()
         content.sound = UNNotificationSound.default
                         
-        for i in 2...6 {
+        for i in DayIndex.monday...DayIndex.friday {
             // Configure the recurring date.
             var dateComponents = DateComponents()
             dateComponents.calendar = Calendar.current
 
-            dateComponents.weekday = i  // Monday to Friday
-            dateComponents.hour = 9    // 9:00 hours
+            dateComponents.weekday = i              // Monday to Friday
+            dateComponents.hour = HourValue.nine    // 9:00 hours
                
             // Create the trigger as a repeating event.
             let trigger = UNCalendarNotificationTrigger(


### PR DESCRIPTION
https://github.com/nimblehq/reportedly-ios/projects/1#card-49059378

## What happened

Once logged in the app, users will be able to receive reminding notifications before reporting session started, i.e. Indochina time 9AM - 10AM
 
## Insight

- [x] Implement logic for enabling daily standup reminder notifications scheduled by default at 9AM local time every weekdays when first install the app
 
## Proof Of Work

<img src="https://user-images.githubusercontent.com/70877098/101873839-460ac980-3bba-11eb-82b6-261ebe2abe77.PNG" width="300">
